### PR TITLE
❇️[feat] 회원 도메인 예외 처리 추가 #29

### DIFF
--- a/src/main/java/com/daon/backend/common/exception/CommonExceptionHandler.java
+++ b/src/main/java/com/daon/backend/common/exception/CommonExceptionHandler.java
@@ -2,6 +2,7 @@ package com.daon.backend.common.exception;
 
 import com.daon.backend.common.response.ErrorResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;

--- a/src/main/java/com/daon/backend/common/exception/DomainSpecificAdvice.java
+++ b/src/main/java/com/daon/backend/common/exception/DomainSpecificAdvice.java
@@ -1,0 +1,14 @@
+package com.daon.backend.common.exception;
+
+import org.springframework.core.annotation.Order;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Order(100)
+@RestControllerAdvice
+public @interface DomainSpecificAdvice {
+}

--- a/src/main/java/com/daon/backend/image/controller/ImageErrorHandler.java
+++ b/src/main/java/com/daon/backend/image/controller/ImageErrorHandler.java
@@ -1,5 +1,6 @@
 package com.daon.backend.image.controller;
 
+import com.daon.backend.common.exception.DomainSpecificAdvice;
 import com.daon.backend.common.response.ErrorResponse;
 import com.daon.backend.image.service.EmptyImageException;
 import com.daon.backend.image.service.ImageIOException;
@@ -8,10 +9,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @Slf4j
-@RestControllerAdvice
+@DomainSpecificAdvice
 public class ImageErrorHandler {
 
     @ExceptionHandler(EmptyImageException.class)

--- a/src/main/java/com/daon/backend/member/controller/MemberErrorHandler.java
+++ b/src/main/java/com/daon/backend/member/controller/MemberErrorHandler.java
@@ -1,0 +1,31 @@
+package com.daon.backend.member.controller;
+
+import com.daon.backend.common.exception.DomainSpecificAdvice;
+import com.daon.backend.common.response.ErrorResponse;
+import com.daon.backend.member.service.AlreadyExistsMemberException;
+import com.daon.backend.member.service.NotFoundEmailException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@Slf4j
+@DomainSpecificAdvice
+public class MemberErrorHandler {
+
+    @ExceptionHandler(AlreadyExistsMemberException.class)
+    public ResponseEntity<ErrorResponse> alreadyExistsMemberExceptionHandle(AlreadyExistsMemberException e) {
+        log.error("{}", e.getMessage());
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse("이미 존재하는 회원입니다."));
+    }
+
+    @ExceptionHandler(NotFoundEmailException.class)
+    public ResponseEntity<ErrorResponse> notFoundEmailExceptionHandle(NotFoundEmailException e) {
+        log.error("{}", e.getMessage());
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse("존재하지 않는 이메일입니다."));
+    }
+}

--- a/src/main/java/com/daon/backend/member/service/AlreadyExistsMemberException.java
+++ b/src/main/java/com/daon/backend/member/service/AlreadyExistsMemberException.java
@@ -1,0 +1,10 @@
+package com.daon.backend.member.service;
+
+import com.daon.backend.common.exception.AbstractException;
+
+public class AlreadyExistsMemberException extends AbstractException {
+
+    public AlreadyExistsMemberException(String memberEmail) {
+        super("이미 존재하는 회원입니다. 요청 받은 이메일 : " + memberEmail);
+    }
+}

--- a/src/main/java/com/daon/backend/member/service/MemberService.java
+++ b/src/main/java/com/daon/backend/member/service/MemberService.java
@@ -6,7 +6,6 @@ import com.daon.backend.member.domain.PasswordEncoder;
 import com.daon.backend.member.dto.SignInRequestDto;
 import com.daon.backend.member.dto.SignUpRequestDto;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,7 +20,7 @@ public class MemberService {
 
     public void signUp(SignUpRequestDto signUpRequestDto) {
         if (memberRepository.findByEmail(signUpRequestDto.getEmail()).isPresent()) {
-            throw new IllegalArgumentException("exists member: " + signUpRequestDto.getEmail());
+            throw new AlreadyExistsMemberException(signUpRequestDto.getEmail());
         }
 
         Member member = signUpRequestDto.toEntity(passwordEncoder);
@@ -31,7 +30,7 @@ public class MemberService {
     public String signIn(SignInRequestDto signInRequestDto) {
         String requestEmail = signInRequestDto.getEmail();
         Member findMember = memberRepository.findByEmail(requestEmail)
-                .orElseThrow(() -> new BadCredentialsException("not found email: " + requestEmail));
+                .orElseThrow(() -> new NotFoundEmailException(requestEmail));
 
         findMember.checkPassword(signInRequestDto.getPassword(), passwordEncoder);
 

--- a/src/main/java/com/daon/backend/member/service/NotFoundEmailException.java
+++ b/src/main/java/com/daon/backend/member/service/NotFoundEmailException.java
@@ -1,0 +1,10 @@
+package com.daon.backend.member.service;
+
+import com.daon.backend.common.exception.AbstractException;
+
+public class NotFoundEmailException extends AbstractException {
+
+    public NotFoundEmailException(String email) {
+        super("존재하지 않는 이메일입니다. 요청 받은 이메일 : " + email);
+    }
+}


### PR DESCRIPTION
- ImageErrorHandler 에도 @DomainSpecificAdvice 적용했습니다.

- @DomainSpecificAdvice
    - 공통 적용된 예외 처리가 컨트롤러 예외 처리보다 우선 실행되어 @Order(100)을 적용해서 컨트롤러 예외 처리에 우선 순위를 두었습니다.
    - Contorller 마다 적용할 때 @Order 애너테이션을 깜빡하는 경우를 생각하여, @RestControllerAdvice와 통합된 애너테이션입니다.