### PR TITLE
[Setting] Swagger UI (springdoc)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,9 @@ dependencies {
     // s3 mock test
     testImplementation 'io.findify:s3mock_2.13:0.2.6'
 
+	// swagger
+	implementation 'org.springdoc:springdoc-openapi-ui:1.6.11'
+
 	compileOnly 'org.projectlombok:lombok'
 	testCompileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/daon/backend/common/exception/CommonExceptionHandler.java
+++ b/src/main/java/com/daon/backend/common/exception/CommonExceptionHandler.java
@@ -1,6 +1,6 @@
 package com.daon.backend.common.exception;
 
-import com.daon.backend.common.response.ApiResponse;
+import com.daon.backend.common.response.CommonResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -17,7 +17,7 @@ import java.util.stream.Collectors;
 public class CommonExceptionHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ApiResponse<Void>> methodArgumentNotValidExceptionHandle(MethodArgumentNotValidException e) {
+    public ResponseEntity<CommonResponse<Void>> methodArgumentNotValidExceptionHandle(MethodArgumentNotValidException e) {
         log.error("데이터 검증 오류");
 
         BindingResult bindingResult = e.getBindingResult();
@@ -27,7 +27,7 @@ public class CommonExceptionHandler {
                 .collect(Collectors.joining(","));
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(ApiResponse.createError(errorMessage));
+                .body(CommonResponse.createError(errorMessage));
     }
 
     private String parseFieldErrorMessage(FieldError fieldError) {
@@ -37,16 +37,16 @@ public class CommonExceptionHandler {
     }
 
     @ExceptionHandler(AbstractException.class)
-    public ResponseEntity<ApiResponse<Void>> abstractExceptionHandle(AbstractException e) {
+    public ResponseEntity<CommonResponse<Void>> abstractExceptionHandle(AbstractException e) {
         log.error("{}", e.getMessage(), e);
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(ApiResponse.createError("서버 오류입니다. 문의 바랍니다."));
+                .body(CommonResponse.createError("서버 오류입니다. 문의 바랍니다."));
     }
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ApiResponse<Void>> allExceptionHandle(Exception e) {
+    public ResponseEntity<CommonResponse<Void>> allExceptionHandle(Exception e) {
         log.error("{}", e.getMessage(), e);
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(ApiResponse.createError("서버 오류입니다. 문의 바랍니다."));
+                .body(CommonResponse.createError("서버 오류입니다. 문의 바랍니다."));
     }
 }

--- a/src/main/java/com/daon/backend/common/response/CommonResponse.java
+++ b/src/main/java/com/daon/backend/common/response/CommonResponse.java
@@ -8,32 +8,32 @@ import lombok.Getter;
 @Getter
 @Builder(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class ApiResponse<T> {
+public class CommonResponse<T> {
 
     private T data;
     private String message;
 
-    public static <T> ApiResponse<T> createSuccess(T data) {
-        return ApiResponse.<T>builder()
+    public static <T> CommonResponse<T> createSuccess(T data) {
+        return CommonResponse.<T>builder()
                 .data(data)
                 .build();
     }
 
-    public static <T> ApiResponse<T> createSuccess(T data, String message) {
-        return ApiResponse.<T>builder()
+    public static <T> CommonResponse<T> createSuccess(T data, String message) {
+        return CommonResponse.<T>builder()
                 .data(data)
                 .message(message)
                 .build();
     }
 
-    public static <T> ApiResponse<T> createError(String message) {
-        return ApiResponse.<T>builder()
+    public static <T> CommonResponse<T> createError(String message) {
+        return CommonResponse.<T>builder()
                 .message(message)
                 .build();
     }
 
-    public static <T> ApiResponse<T> createError(T data, String message) {
-        return ApiResponse.<T>builder()
+    public static <T> CommonResponse<T> createError(T data, String message) {
+        return CommonResponse.<T>builder()
                 .data(data)
                 .message(message)
                 .build();

--- a/src/main/java/com/daon/backend/config/SwaggerConfig.java
+++ b/src/main/java/com/daon/backend/config/SwaggerConfig.java
@@ -1,0 +1,26 @@
+package com.daon.backend.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .components(new Components())
+                .info(apiInfo());
+    }
+
+    private Info apiInfo() {
+        return new Info()
+                .title("Springdoc test!!")
+                .description("Swagger UI 설명란입니다! 버전 정보를 설정 파일로 뺄까요 말까요!!, " +
+                        "Request Dto 등 모든 필드에 부가 정보를 다는 것은 번거롭기도 하고 논의된 사항(시간 자원의 한계)에 맞지 않기 때문에 우선 제외했습니다.")
+                .version("1.0.0");
+    }
+}

--- a/src/main/java/com/daon/backend/image/controller/ImageController.java
+++ b/src/main/java/com/daon/backend/image/controller/ImageController.java
@@ -4,6 +4,10 @@ import com.daon.backend.common.response.CommonResponse;
 import com.daon.backend.image.dto.UploadImageResponseDto;
 import com.daon.backend.image.service.ImageFileService;
 import com.daon.backend.image.service.UploadedImage;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -12,13 +16,17 @@ import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
 @RestController
-
 @RequiredArgsConstructor
+@Tag(name = "Image", description = "Image domain API")
 @RequestMapping("/api/images")
 public class ImageController {
 
     private final ImageFileService imageFileService;
 
+    @Operation(summary = "이미지 업로드", description = "이미지 업로드 요청입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "이미지 업로드 성공")
+    })
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping
     public CommonResponse<UploadImageResponseDto> uploadImage(@RequestParam("image") MultipartFile imageFile) {

--- a/src/main/java/com/daon/backend/image/controller/ImageController.java
+++ b/src/main/java/com/daon/backend/image/controller/ImageController.java
@@ -1,6 +1,6 @@
 package com.daon.backend.image.controller;
 
-import com.daon.backend.common.response.ApiResponse;
+import com.daon.backend.common.response.CommonResponse;
 import com.daon.backend.image.dto.UploadImageResponseDto;
 import com.daon.backend.image.service.ImageFileService;
 import com.daon.backend.image.service.UploadedImage;
@@ -21,8 +21,8 @@ public class ImageController {
 
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping
-    public ApiResponse<UploadImageResponseDto> uploadImage(@RequestParam("image") MultipartFile imageFile) {
+    public CommonResponse<UploadImageResponseDto> uploadImage(@RequestParam("image") MultipartFile imageFile) {
         UploadedImage uploadedImage = imageFileService.upload(imageFile);
-        return ApiResponse.createSuccess(new UploadImageResponseDto(uploadedImage.getUrl()));
+        return CommonResponse.createSuccess(new UploadImageResponseDto(uploadedImage.getUrl()));
     }
 }

--- a/src/main/java/com/daon/backend/image/controller/ImageErrorHandler.java
+++ b/src/main/java/com/daon/backend/image/controller/ImageErrorHandler.java
@@ -1,7 +1,7 @@
 package com.daon.backend.image.controller;
 
 import com.daon.backend.common.exception.DomainSpecificAdvice;
-import com.daon.backend.common.response.ApiResponse;
+import com.daon.backend.common.response.CommonResponse;
 import com.daon.backend.image.service.EmptyImageException;
 import com.daon.backend.image.service.ImageIOException;
 import com.daon.backend.image.service.NotAllowedContentTypeException;
@@ -15,23 +15,23 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 public class ImageErrorHandler {
 
     @ExceptionHandler(EmptyImageException.class)
-    public ResponseEntity<ApiResponse<Void>> emptyImageExceptionHandle(EmptyImageException e) {
+    public ResponseEntity<CommonResponse<Void>> emptyImageExceptionHandle(EmptyImageException e) {
         log.error("{}", e.getMessage());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(ApiResponse.createError("빈 이미지 파일입니다."));
+                .body(CommonResponse.createError("빈 이미지 파일입니다."));
     }
 
     @ExceptionHandler(NotAllowedContentTypeException.class)
-    public ResponseEntity<ApiResponse<Void>> notAllowedContentTypeExceptionHandle(NotAllowedContentTypeException e) {
+    public ResponseEntity<CommonResponse<Void>> notAllowedContentTypeExceptionHandle(NotAllowedContentTypeException e) {
         log.error("{}", e.getMessage());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(ApiResponse.createError("이미지는 .jpg, .jpeg, .png 형식이어야 합니다."));
+                .body(CommonResponse.createError("이미지는 .jpg, .jpeg, .png 형식이어야 합니다."));
     }
 
     @ExceptionHandler(ImageIOException.class)
-    public ResponseEntity<ApiResponse<Void>> imageIOExceptionHandle(ImageIOException e) {
+    public ResponseEntity<CommonResponse<Void>> imageIOExceptionHandle(ImageIOException e) {
         log.error("이미지 입출력 오류 발생...", e);
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(ApiResponse.createError("이미지 업로드 중 오류 발생"));
+                .body(CommonResponse.createError("이미지 업로드 중 오류 발생"));
     }
 }

--- a/src/main/java/com/daon/backend/member/controller/MemberController.java
+++ b/src/main/java/com/daon/backend/member/controller/MemberController.java
@@ -1,10 +1,11 @@
 package com.daon.backend.member.controller;
 
-import com.daon.backend.common.response.ApiResponse;
+import com.daon.backend.common.response.CommonResponse;
 import com.daon.backend.member.dto.SignInRequestDto;
 import com.daon.backend.member.dto.SignUpRequestDto;
 import com.daon.backend.member.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -27,22 +28,22 @@ public class MemberController {
 
     @Operation(summary = "회원가입", description = "회원가입 요청입니다.")
     @ApiResponses(value = {
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "회원가입 성공")
+            @ApiResponse(responseCode = "201", description = "회원가입 성공")
     })
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/sign-up")
-    public ApiResponse<Void> signUp(@RequestBody @Valid SignUpRequestDto signUpRequestDto) {
+    public CommonResponse<Void> signUp(@RequestBody @Valid SignUpRequestDto signUpRequestDto) {
         memberService.signUp(signUpRequestDto);
 
-        return ApiResponse.createSuccess(null);
+        return CommonResponse.createSuccess(null);
     }
 
     @Operation(summary = "로그인", description = "로그인 요청입니다.")
     @ApiResponses(value = {
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "로그인 성공")
+            @ApiResponse(responseCode = "200", description = "로그인 성공")
     })
     @PostMapping("/sign-in")
-    public ResponseEntity<ApiResponse<Void>> signIn(@RequestBody @Valid SignInRequestDto signInRequestDto) {
+    public ResponseEntity<CommonResponse<Void>> signIn(@RequestBody @Valid SignInRequestDto signInRequestDto) {
         String token = memberService.signIn(signInRequestDto);
 
         return ResponseEntity.status(HttpStatus.OK)
@@ -50,6 +51,6 @@ public class MemberController {
                         HttpHeaders.AUTHORIZATION,
                         BEARER_TYPE + token
                 ))
-                .body(ApiResponse.createSuccess(null));
+                .body(CommonResponse.createSuccess(null));
     }
 }

--- a/src/main/java/com/daon/backend/member/controller/MemberController.java
+++ b/src/main/java/com/daon/backend/member/controller/MemberController.java
@@ -4,6 +4,9 @@ import com.daon.backend.common.response.ApiResponse;
 import com.daon.backend.member.dto.SignInRequestDto;
 import com.daon.backend.member.dto.SignUpRequestDto;
 import com.daon.backend.member.service.MemberService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -15,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.Valid;
 
+@Tag(name = "Member", description = "Member domain API")
 @RequiredArgsConstructor
 @RequestMapping("/api")
 @RestController
@@ -24,6 +28,10 @@ public class MemberController {
 
     private static final String BEARER_TYPE = "Bearer ";
 
+    @Operation(summary = "회원가입", description = "회원가입 요청입니다.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "회원가입 성공")
+    })
     @PostMapping("/sign-up")
     public ApiResponse<Void> signUp(@RequestBody @Valid SignUpRequestDto signUpRequestDto) {
         memberService.signUp(signUpRequestDto);
@@ -31,7 +39,10 @@ public class MemberController {
         return ApiResponse.createSuccess(null);
     }
 
-    // 응답 헤더에 접근해야 해서 예외적으로 ResponseEntity 사용
+    @Operation(summary = "로그인", description = "로그인 요청입니다.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "로그인 성공")
+    })
     @PostMapping("/sign-in")
     public ResponseEntity<ApiResponse<Void>> signIn(@RequestBody @Valid SignInRequestDto signInRequestDto) {
         String token = memberService.signIn(signInRequestDto);

--- a/src/main/java/com/daon/backend/member/controller/MemberErrorHandler.java
+++ b/src/main/java/com/daon/backend/member/controller/MemberErrorHandler.java
@@ -1,7 +1,7 @@
 package com.daon.backend.member.controller;
 
 import com.daon.backend.common.exception.DomainSpecificAdvice;
-import com.daon.backend.common.response.ApiResponse;
+import com.daon.backend.common.response.CommonResponse;
 import com.daon.backend.member.domain.PasswordMismatchException;
 import com.daon.backend.member.service.AlreadyExistsMemberException;
 import com.daon.backend.member.service.NotFoundEmailException;
@@ -15,26 +15,26 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 public class MemberErrorHandler {
 
     @ExceptionHandler(AlreadyExistsMemberException.class)
-    public ResponseEntity<ApiResponse<Void>> alreadyExistsMemberExceptionHandle(AlreadyExistsMemberException e) {
+    public ResponseEntity<CommonResponse<Void>> alreadyExistsMemberExceptionHandle(AlreadyExistsMemberException e) {
         log.error("{}", e.getMessage());
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(ApiResponse.createError("이미 존재하는 회원입니다."));
+                .body(CommonResponse.createError("이미 존재하는 회원입니다."));
     }
 
     @ExceptionHandler(NotFoundEmailException.class)
-    public ResponseEntity<ApiResponse<Void>> notFoundEmailExceptionHandle(NotFoundEmailException e) {
+    public ResponseEntity<CommonResponse<Void>> notFoundEmailExceptionHandle(NotFoundEmailException e) {
         log.error("{}", e.getMessage());
 
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                .body(ApiResponse.createError("존재하지 않는 이메일입니다."));
+                .body(CommonResponse.createError("존재하지 않는 이메일입니다."));
     }
 
     @ExceptionHandler(PasswordMismatchException.class)
-    public ResponseEntity<ApiResponse<Void>> passwordMismatchExceptionHandle(PasswordMismatchException e) {
+    public ResponseEntity<CommonResponse<Void>> passwordMismatchExceptionHandle(PasswordMismatchException e) {
         log.error("{}", e.getMessage());
 
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                .body(ApiResponse.createError("비밀번호가 일치하지 않습니다."));
+                .body(CommonResponse.createError("비밀번호가 일치하지 않습니다."));
     }
 }

--- a/src/main/java/com/daon/backend/security/SecurityExceptionHandler.java
+++ b/src/main/java/com/daon/backend/security/SecurityExceptionHandler.java
@@ -1,7 +1,7 @@
 package com.daon.backend.security;
 
 import com.daon.backend.common.exception.DomainSpecificAdvice;
-import com.daon.backend.common.response.ApiResponse;
+import com.daon.backend.common.response.CommonResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -12,9 +12,9 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 public class SecurityExceptionHandler {
 
     @ExceptionHandler(MemberNotAuthenticatedException.class)
-    public ResponseEntity<ApiResponse<Void>> memberNotAuthenticatedExceptionHandle(MemberNotAuthenticatedException e) {
+    public ResponseEntity<CommonResponse<Void>> memberNotAuthenticatedExceptionHandle(MemberNotAuthenticatedException e) {
         log.info("{}", e.getMessage());
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                .body(ApiResponse.createError("인증되지 않은 사용자의 요청입니다."));
+                .body(CommonResponse.createError("인증되지 않은 사용자의 요청입니다."));
     }
 }

--- a/src/main/java/com/daon/backend/task/controller/ProjectController.java
+++ b/src/main/java/com/daon/backend/task/controller/ProjectController.java
@@ -1,6 +1,6 @@
 package com.daon.backend.task.controller;
 
-import com.daon.backend.common.response.ApiResponse;
+import com.daon.backend.common.response.CommonResponse;
 import com.daon.backend.task.dto.request.CreateProjectRequestDto;
 import com.daon.backend.task.dto.response.CreateProjectResponseDto;
 import com.daon.backend.task.dto.response.ProjectListResponseDto;
@@ -22,17 +22,17 @@ public class ProjectController {
 
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping
-    public ApiResponse<CreateProjectResponseDto> createProject(
+    public CommonResponse<CreateProjectResponseDto> createProject(
             @PathVariable Long workspaceId,
             @RequestBody @Valid CreateProjectRequestDto requestDto
     ) {
         Long projectId = projectService.createProject(workspaceId, requestDto);
-        return ApiResponse.createSuccess(new CreateProjectResponseDto(projectId));
+        return CommonResponse.createSuccess(new CreateProjectResponseDto(projectId));
     }
 
     @GetMapping
-    public ApiResponse<ProjectListResponseDto> projectList(@PathVariable Long workspaceId) {
+    public CommonResponse<ProjectListResponseDto> projectList(@PathVariable Long workspaceId) {
         ProjectListResponseDto projectListResponseDto = projectService.findAllProjectInWorkspace(workspaceId);
-        return ApiResponse.createSuccess(projectListResponseDto);
+        return CommonResponse.createSuccess(projectListResponseDto);
     }
 }

--- a/src/main/java/com/daon/backend/task/controller/ProjectController.java
+++ b/src/main/java/com/daon/backend/task/controller/ProjectController.java
@@ -5,6 +5,10 @@ import com.daon.backend.task.dto.request.CreateProjectRequestDto;
 import com.daon.backend.task.dto.response.CreateProjectResponseDto;
 import com.daon.backend.task.dto.response.ProjectListResponseDto;
 import com.daon.backend.task.service.ProjectService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -15,11 +19,16 @@ import javax.validation.Valid;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "Project", description = "Project domain API")
 @RequestMapping("/api/workspaces/{workspaceId}/projects")
 public class ProjectController {
 
     private final ProjectService projectService;
 
+    @Operation(summary = "프로젝트 생성", description = "프로젝트 생성 요청입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "프로젝트 생성 성공")
+    })
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping
     public CommonResponse<CreateProjectResponseDto> createProject(
@@ -30,6 +39,10 @@ public class ProjectController {
         return CommonResponse.createSuccess(new CreateProjectResponseDto(projectId));
     }
 
+    @Operation(summary = "프로젝트 목록 조회", description = "프로젝트 목록 조회 요청입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "프로젝트 목록 조회 성공")
+    })
     @GetMapping
     public CommonResponse<ProjectListResponseDto> projectList(@PathVariable Long workspaceId) {
         ProjectListResponseDto projectListResponseDto = projectService.findAllProjectInWorkspace(workspaceId);

--- a/src/main/java/com/daon/backend/task/controller/WorkspaceController.java
+++ b/src/main/java/com/daon/backend/task/controller/WorkspaceController.java
@@ -5,6 +5,10 @@ import com.daon.backend.task.dto.request.CreateWorkspaceRequestDto;
 import com.daon.backend.task.dto.response.CreateWorkspaceResponseDto;
 import com.daon.backend.task.dto.response.WorkspaceListResponseDto;
 import com.daon.backend.task.service.WorkspaceService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -15,11 +19,16 @@ import javax.validation.Valid;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "Workspace", description = "Workspace domain API")
 @RequestMapping("/api/workspaces")
 public class WorkspaceController {
 
     private final WorkspaceService workspaceService;
 
+    @Operation(summary = "워크스페이스 생성", description = "워크스페이스 생성 요청입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "워크스페이스 생성 성공")
+    })
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping
     public CommonResponse<CreateWorkspaceResponseDto> createWorkspace(
@@ -29,6 +38,10 @@ public class WorkspaceController {
         return CommonResponse.createSuccess(new CreateWorkspaceResponseDto(workspaceId));
     }
 
+    @Operation(summary = "워크스페이스 목록 조회", description = "워크스페이스 목록 조회 요청입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "워크스페이스 목록 조회 성공")
+    })
     @GetMapping
     public CommonResponse<WorkspaceListResponseDto> workspaceList() {
         WorkspaceListResponseDto workspaceListResponseDto = workspaceService.findAllWorkspace();

--- a/src/main/java/com/daon/backend/task/controller/WorkspaceController.java
+++ b/src/main/java/com/daon/backend/task/controller/WorkspaceController.java
@@ -1,6 +1,6 @@
 package com.daon.backend.task.controller;
 
-import com.daon.backend.common.response.ApiResponse;
+import com.daon.backend.common.response.CommonResponse;
 import com.daon.backend.task.dto.request.CreateWorkspaceRequestDto;
 import com.daon.backend.task.dto.response.CreateWorkspaceResponseDto;
 import com.daon.backend.task.dto.response.WorkspaceListResponseDto;
@@ -22,16 +22,16 @@ public class WorkspaceController {
 
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping
-    public ApiResponse<CreateWorkspaceResponseDto> createWorkspace(
+    public CommonResponse<CreateWorkspaceResponseDto> createWorkspace(
             @RequestBody @Valid CreateWorkspaceRequestDto requestDto
     ) {
         Long workspaceId = workspaceService.createWorkspace(requestDto);
-        return ApiResponse.createSuccess(new CreateWorkspaceResponseDto(workspaceId));
+        return CommonResponse.createSuccess(new CreateWorkspaceResponseDto(workspaceId));
     }
 
     @GetMapping
-    public ApiResponse<WorkspaceListResponseDto> workspaceList() {
+    public CommonResponse<WorkspaceListResponseDto> workspaceList() {
         WorkspaceListResponseDto workspaceListResponseDto = workspaceService.findAllWorkspace();
-        return ApiResponse.createSuccess(workspaceListResponseDto);
+        return CommonResponse.createSuccess(workspaceListResponseDto);
     }
 }

--- a/src/main/java/com/daon/backend/task/controller/WorkspaceExceptionHandler.java
+++ b/src/main/java/com/daon/backend/task/controller/WorkspaceExceptionHandler.java
@@ -1,7 +1,7 @@
 package com.daon.backend.task.controller;
 
 import com.daon.backend.common.exception.DomainSpecificAdvice;
-import com.daon.backend.common.response.ApiResponse;
+import com.daon.backend.common.response.CommonResponse;
 import com.daon.backend.task.domain.workspace.NotWorkspaceParticipantException;
 import com.daon.backend.task.domain.workspace.WorkspaceNotFoundException;
 import lombok.extern.slf4j.Slf4j;
@@ -14,16 +14,16 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 public class WorkspaceExceptionHandler {
 
     @ExceptionHandler(WorkspaceNotFoundException.class)
-    public ResponseEntity<ApiResponse<Void>> workspaceNotFoundExceptionHandle(WorkspaceNotFoundException e) {
+    public ResponseEntity<CommonResponse<Void>> workspaceNotFoundExceptionHandle(WorkspaceNotFoundException e) {
         log.info("{}", e.getMessage());
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                .body(ApiResponse.createError("요청한 워크스페이스는 존재하지 않습니다."));
+                .body(CommonResponse.createError("요청한 워크스페이스는 존재하지 않습니다."));
     }
 
     @ExceptionHandler(NotWorkspaceParticipantException.class)
-    public ResponseEntity<ApiResponse<Void>> notWorkspaceParticipantExceptionHandle(NotWorkspaceParticipantException e) {
+    public ResponseEntity<CommonResponse<Void>> notWorkspaceParticipantExceptionHandle(NotWorkspaceParticipantException e) {
         log.info("{}", e.getMessage());
         return ResponseEntity.status(HttpStatus.FORBIDDEN)
-                .body(ApiResponse.createError("해당 워크스페이스에 접근 권한이 없습니다."));
+                .body(CommonResponse.createError("해당 워크스페이스에 접근 권한이 없습니다."));
     }
 }


### PR DESCRIPTION
- Springdoc 1.6.11 version 적용
- MemberController에 테스트용으로 정말 기본적인 정보만 작성해서 적용했습니다.
- Swagger 관련 설정은 우선 config -> application-data.yml 의 local 부분에만 작성 했습니다.
- ApiResponse 클래스와 애너테이션 명이 겹칩니다.

+++
- 당장 간편하게 확인할 수 있는 용도로 사용하기 때문에, Http 요청 시 발생할 수 있는 에러 응답과 schema 구성은 제외했습니다.
--- 

- path : /api-docs
- https://www.notion.so/API-dbc93f573b354071a4e1d681bcd23ecd?pvs=4