### PR TITLE
권한 처리 interceptor 설정 및 적용

### DIFF
--- a/src/main/java/com/daon/backend/auth/controller/AuthController.java
+++ b/src/main/java/com/daon/backend/auth/controller/AuthController.java
@@ -1,10 +1,10 @@
 package com.daon.backend.auth.controller;
 
-import com.daon.backend.auth.domain.UnauthorizedException;
-import com.daon.backend.auth.service.AuthService;
 import com.daon.backend.auth.domain.Tokens;
-import com.daon.backend.common.response.CommonResponse;
+import com.daon.backend.auth.domain.UnauthenticatedMemberException;
 import com.daon.backend.auth.dto.SignInRequestDto;
+import com.daon.backend.auth.service.AuthService;
+import com.daon.backend.common.response.CommonResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -14,7 +14,10 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
@@ -67,12 +70,12 @@ public class AuthController {
     @PostMapping("/reissue")
     public ResponseEntity<CommonResponse<Void>> reissueToken(HttpServletRequest request) {
         Cookie[] cookies = request.getCookies();
-        if (cookies == null) throw new UnauthorizedException();
+        if (cookies == null) throw new UnauthenticatedMemberException();
         String refreshTokenValue = Arrays.stream(cookies)
                 .filter(cookie -> cookie.getName().equals("rtk"))
                 .findFirst()
                 .map(Cookie::getValue)
-                .orElseThrow(UnauthorizedException::new);
+                .orElseThrow(UnauthenticatedMemberException::new);
 
         Tokens tokens = authService.reissue(refreshTokenValue);
         String rtkCookie = tokens.getRefreshToken() != null ? ResponseCookie.from("rtk", tokens.getRefreshToken().getValue())

--- a/src/main/java/com/daon/backend/auth/controller/AuthExceptionHandler.java
+++ b/src/main/java/com/daon/backend/auth/controller/AuthExceptionHandler.java
@@ -1,7 +1,7 @@
 package com.daon.backend.auth.controller;
 
 import com.daon.backend.auth.domain.InvalidRefreshTokenException;
-import com.daon.backend.auth.domain.UnauthorizedException;
+import com.daon.backend.auth.domain.UnauthenticatedMemberException;
 import com.daon.backend.common.response.CommonResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -20,8 +20,8 @@ public class AuthExceptionHandler {
                 .body(CommonResponse.createError("로그인이 만료되었습니다."));
     }
 
-    @ExceptionHandler(UnauthorizedException.class)
-    public ResponseEntity<CommonResponse<Void>> unauthorizedExceptionHandle(UnauthorizedException e) {
+    @ExceptionHandler(UnauthenticatedMemberException.class)
+    public ResponseEntity<CommonResponse<Void>> unauthorizedExceptionHandle(UnauthenticatedMemberException e) {
         log.error("{}", e.getMessage());
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                 .body(CommonResponse.createError("로그인이 필요한 서비스입니다."));

--- a/src/main/java/com/daon/backend/auth/domain/UnauthenticatedMemberException.java
+++ b/src/main/java/com/daon/backend/auth/domain/UnauthenticatedMemberException.java
@@ -2,9 +2,9 @@ package com.daon.backend.auth.domain;
 
 import com.daon.backend.common.exception.AbstractException;
 
-public class UnauthorizedException extends AbstractException {
+public class UnauthenticatedMemberException extends AbstractException {
 
-    public UnauthorizedException() {
+    public UnauthenticatedMemberException() {
         super("인증되지 않은 사용자입니다.");
     }
 }

--- a/src/main/java/com/daon/backend/auth/infrastructure/JwtManagerImpl.java
+++ b/src/main/java/com/daon/backend/auth/infrastructure/JwtManagerImpl.java
@@ -83,7 +83,7 @@ public class JwtManagerImpl implements JwtManager {
         }
 
         String memberId = refreshTokenRepository.findMemberIdByRtk(refreshTokenValue)
-                .orElseThrow(UnauthorizedException::new);
+                .orElseThrow(UnauthenticatedMemberException::new);
 
         Token accessToken = createMemberAccessToken(memberId);
         Payload rtkPayload = parse(refreshTokenValue);

--- a/src/main/java/com/daon/backend/config/WebConfig.java
+++ b/src/main/java/com/daon/backend/config/WebConfig.java
@@ -1,0 +1,19 @@
+package com.daon.backend.config;
+
+import com.daon.backend.task.infrastructure.CheckRoleInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@RequiredArgsConstructor
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    private final CheckRoleInterceptor checkRoleInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(checkRoleInterceptor);
+    }
+}

--- a/src/main/java/com/daon/backend/task/controller/AuthorizedExceptionHandler.java
+++ b/src/main/java/com/daon/backend/task/controller/AuthorizedExceptionHandler.java
@@ -1,0 +1,21 @@
+package com.daon.backend.task.controller;
+
+import com.daon.backend.common.exception.DomainSpecificAdvice;
+import com.daon.backend.common.response.CommonResponse;
+import com.daon.backend.task.domain.authority.UnAuthorizedMemberException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@Slf4j
+@DomainSpecificAdvice
+public class AuthorizedExceptionHandler {
+
+    @ExceptionHandler(UnAuthorizedMemberException.class)
+    public ResponseEntity<CommonResponse<Void>> unAuthorizedMemberException(UnAuthorizedMemberException e) {
+        log.info("{}", e.getMessage());
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                .body(CommonResponse.createError("해당 요청에 대한 권한이 없습니다."));
+    }
+}

--- a/src/main/java/com/daon/backend/task/controller/BoardController.java
+++ b/src/main/java/com/daon/backend/task/controller/BoardController.java
@@ -1,6 +1,7 @@
 package com.daon.backend.task.controller;
 
 import com.daon.backend.common.response.CommonResponse;
+import com.daon.backend.task.domain.authority.CheckRole;
 import com.daon.backend.task.dto.request.CreateBoardRequestDto;
 import com.daon.backend.task.dto.response.FindBoardsResponseDto;
 import com.daon.backend.task.service.BoardService;
@@ -12,6 +13,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+
+import static com.daon.backend.task.domain.authority.Authority.BD_CREATE;
+import static com.daon.backend.task.domain.authority.Authority.BD_READ;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/workspaces/{workspaceId}/projects/{projectId}/boards")
@@ -25,6 +29,7 @@ public class BoardController {
             @ApiResponse(responseCode = "201", description = "보드 생성 성공")
     })
     @ResponseStatus(HttpStatus.CREATED)
+    @CheckRole(authority = BD_CREATE)
     @PostMapping
     public CommonResponse<Void> createBoard(@PathVariable("workspaceId") Long workspaceId,
                                                               @PathVariable("projectId") Long projectId,
@@ -38,6 +43,7 @@ public class BoardController {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "보드 목록 조회 성공")
     })
+    @CheckRole(authority = BD_READ)
     @GetMapping
     public CommonResponse<FindBoardsResponseDto> findBoards(@PathVariable("workspaceId") Long workspaceId,
                                                             @PathVariable("projectId") Long projectId) {

--- a/src/main/java/com/daon/backend/task/controller/ProjectController.java
+++ b/src/main/java/com/daon/backend/task/controller/ProjectController.java
@@ -1,6 +1,8 @@
 package com.daon.backend.task.controller;
 
 import com.daon.backend.common.response.CommonResponse;
+import com.daon.backend.task.domain.authority.Authority;
+import com.daon.backend.task.domain.authority.CheckRole;
 import com.daon.backend.task.dto.request.CreateProjectRequestDto;
 import com.daon.backend.task.dto.response.CreateProjectResponseDto;
 import com.daon.backend.task.dto.response.ProjectListResponseDto;
@@ -30,6 +32,7 @@ public class ProjectController {
             @ApiResponse(responseCode = "201", description = "프로젝트 생성 성공")
     })
     @ResponseStatus(HttpStatus.CREATED)
+    @CheckRole(authority = Authority.PJ_CREATE)
     @PostMapping
     public CommonResponse<CreateProjectResponseDto> createProject(
             @PathVariable Long workspaceId,
@@ -43,6 +46,7 @@ public class ProjectController {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "프로젝트 목록 조회 성공")
     })
+    @CheckRole(authority = Authority.PJ_READ)
     @GetMapping
     public CommonResponse<ProjectListResponseDto> projectList(@PathVariable Long workspaceId) {
         ProjectListResponseDto projectListResponseDto = projectService.findAllProjectInWorkspace(workspaceId);

--- a/src/main/java/com/daon/backend/task/controller/WorkspaceController.java
+++ b/src/main/java/com/daon/backend/task/controller/WorkspaceController.java
@@ -1,6 +1,7 @@
 package com.daon.backend.task.controller;
 
 import com.daon.backend.common.response.CommonResponse;
+import com.daon.backend.task.domain.authority.CheckRole;
 import com.daon.backend.task.dto.request.CheckJoinCodeRequestDto;
 import com.daon.backend.task.dto.request.CreateWorkspaceRequestDto;
 import com.daon.backend.task.dto.request.JoinWorkspaceRequestDto;
@@ -16,6 +17,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+
+import static com.daon.backend.task.domain.authority.Authority.WSP_INVITE;
+import static com.daon.backend.task.domain.authority.Authority.WS_READ;
 
 @Slf4j
 @RestController
@@ -43,6 +47,7 @@ public class WorkspaceController {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "워크스페이스 목록 조회 성공")
     })
+    @CheckRole(authority = WS_READ)
     @GetMapping
     public CommonResponse<WorkspaceListResponseDto> workspaceList() {
         WorkspaceListResponseDto workspaceListResponseDto = workspaceService.findAllWorkspace();
@@ -53,6 +58,7 @@ public class WorkspaceController {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "참여코드 확인 성공")
     })
+    @CheckRole(authority = WSP_INVITE)
     @PostMapping("/code")
     public CommonResponse<Void> checkJoinCode(@RequestBody @Valid CheckJoinCodeRequestDto requestDto) {
         workspaceService.checkJoinCode(requestDto);
@@ -75,6 +81,7 @@ public class WorkspaceController {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "프로필 조회 성공")
     })
+    @CheckRole(authority = WS_READ)
     @GetMapping("/{workspaceId}/profile/me")
     public CommonResponse<FindProfileResponseDto> findProfile(@PathVariable("workspaceId") Long workspaceId) {
         FindProfileResponseDto result = workspaceService.findProfile(workspaceId);
@@ -86,6 +93,7 @@ public class WorkspaceController {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "워크스페이스 구성원 목록 조회 성공")
     })
+    @CheckRole(authority = WS_READ)
     @GetMapping("/{workspaceId}/participants")
     public CommonResponse<FindParticipantsResponseDto> findParticipants(@PathVariable("workspaceId") Long workspaceId) {
         FindParticipantsResponseDto result = workspaceService.findParticipants(workspaceId);

--- a/src/main/java/com/daon/backend/task/domain/authority/Authority.java
+++ b/src/main/java/com/daon/backend/task/domain/authority/Authority.java
@@ -1,9 +1,7 @@
-package com.daon.backend.task.domain;
+package com.daon.backend.task.domain.authority;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-
-import java.util.List;
 
 @Getter
 @RequiredArgsConstructor
@@ -22,6 +20,11 @@ public enum Authority {
     PJ_READ("프로젝트 조회"),
     PJ_UPDATE("프로젝트 수정"),
     PJ_DELETE("프로젝트 삭제"),
+    //board
+    BD_CREATE("보드 생성"),
+    BD_READ("보드 조회"),
+    BD_UPDATE("보드 수정"),
+    BD_DELETE("보드 삭제"),
     // task
     TSK_CREATE("할 일 생성"),
     TSK_READ("할 일 읽기"),

--- a/src/main/java/com/daon/backend/task/domain/authority/CheckRole.java
+++ b/src/main/java/com/daon/backend/task/domain/authority/CheckRole.java
@@ -1,0 +1,13 @@
+package com.daon.backend.task.domain.authority;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CheckRole {
+
+    Authority[] authority();
+}

--- a/src/main/java/com/daon/backend/task/domain/authority/UnAuthorizedMemberException.java
+++ b/src/main/java/com/daon/backend/task/domain/authority/UnAuthorizedMemberException.java
@@ -1,0 +1,12 @@
+package com.daon.backend.task.domain.authority;
+
+import com.daon.backend.common.exception.AbstractException;
+
+import java.util.Set;
+
+public class UnAuthorizedMemberException extends AbstractException {
+
+    public UnAuthorizedMemberException(Set<Authority> requiredAuthorities) {
+        super("해당 요청에 대한 권한이 없습니다. 필요한 권한: " + requiredAuthorities.toString());
+    }
+}

--- a/src/main/java/com/daon/backend/task/domain/workspace/Role.java
+++ b/src/main/java/com/daon/backend/task/domain/workspace/Role.java
@@ -1,12 +1,12 @@
 package com.daon.backend.task.domain.workspace;
 
-import com.daon.backend.task.domain.Authority;
+import com.daon.backend.task.domain.authority.Authority;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 import java.util.List;
 
-import static com.daon.backend.task.domain.Authority.*;
+import static com.daon.backend.task.domain.authority.Authority.*;
 
 @Getter
 @RequiredArgsConstructor
@@ -25,6 +25,7 @@ public enum Role {
             List.of(
                     WS_READ,
                     PJ_CREATE, PJ_READ, PJ_UPDATE, PJ_DELETE,
+                    BD_CREATE, BD_READ, BD_UPDATE, BD_DELETE,
                     TSK_CREATE, TSK_READ, TSK_UPDATE, TSK_DELETE
             )
     ),
@@ -37,6 +38,7 @@ public enum Role {
             List.of(
                     WS_READ,
                     PJ_READ,
+                    BD_READ,
                     TSK_CREATE, TSK_READ, TSK_UPDATE, TSK_DELETE
             )
     ),

--- a/src/main/java/com/daon/backend/task/domain/workspace/WorkspaceRepository.java
+++ b/src/main/java/com/daon/backend/task/domain/workspace/WorkspaceRepository.java
@@ -18,4 +18,6 @@ public interface WorkspaceRepository {
     List<WorkspaceParticipant> findWorkspaceParticipantsByWorkspaceId(Long workspaceId);
 
     boolean existsWorkspaceParticipantByMemberIdAndWorkspaceId(String memberId, Long workspaceId);
+
+    Role findParticipantRoleByMemberId(String memberId, Long workspaceId);
 }

--- a/src/main/java/com/daon/backend/task/dto/response/CheckRoleResponseDto.java
+++ b/src/main/java/com/daon/backend/task/dto/response/CheckRoleResponseDto.java
@@ -1,0 +1,12 @@
+package com.daon.backend.task.dto.response;
+
+import com.daon.backend.task.domain.workspace.Role;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CheckRoleResponseDto {
+
+    private Role role;
+}

--- a/src/main/java/com/daon/backend/task/infrastructure/CheckRoleInterceptor.java
+++ b/src/main/java/com/daon/backend/task/infrastructure/CheckRoleInterceptor.java
@@ -1,0 +1,63 @@
+package com.daon.backend.task.infrastructure;
+
+import com.daon.backend.auth.domain.UnauthenticatedMemberException;
+import com.daon.backend.task.domain.authority.Authority;
+import com.daon.backend.task.domain.authority.CheckRole;
+import com.daon.backend.task.domain.authority.UnAuthorizedMemberException;
+import com.daon.backend.task.dto.response.CheckRoleResponseDto;
+import com.daon.backend.task.service.WorkspaceService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.HandlerMapping;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class CheckRoleInterceptor implements HandlerInterceptor {
+
+    private final WorkspaceService workspaceService;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+
+        if (!(handler instanceof HandlerMethod)) {
+            return true;
+        }
+
+        HandlerMethod handlerMethod = (HandlerMethod) handler;
+
+        CheckRole checkRole = handlerMethod.getMethodAnnotation(CheckRole.class);
+        if (checkRole == null) {
+            return true;
+        }
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new UnauthenticatedMemberException();
+        }
+
+        final Map<String, String> pathVariables = (Map<String, String>) request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
+        Long workspaceId = Long.valueOf(pathVariables.get("workspaceId"));
+
+        CheckRoleResponseDto checkRoleResponseDto = workspaceService.findParticipantRole(workspaceId);
+        Set<Authority> memberAuthorities = new HashSet<>(checkRoleResponseDto.getRole().getAuthorities());
+        Set<Authority> requiredAuthorities = new HashSet<>(List.of(checkRole.authority()));
+        if (!memberAuthorities.containsAll(requiredAuthorities)) {
+            throw new UnAuthorizedMemberException(requiredAuthorities);
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/com/daon/backend/task/infrastructure/WorkspaceRepositoryImpl.java
+++ b/src/main/java/com/daon/backend/task/infrastructure/WorkspaceRepositoryImpl.java
@@ -1,13 +1,17 @@
 package com.daon.backend.task.infrastructure;
 
+import com.daon.backend.task.domain.workspace.Role;
 import com.daon.backend.task.domain.workspace.Workspace;
 import com.daon.backend.task.domain.workspace.WorkspaceParticipant;
 import com.daon.backend.task.domain.workspace.WorkspaceRepository;
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
+
+import static com.daon.backend.task.domain.workspace.QWorkspaceParticipant.workspaceParticipant;
 
 @Repository
 @RequiredArgsConstructor
@@ -15,6 +19,7 @@ public class WorkspaceRepositoryImpl implements WorkspaceRepository {
 
     private final WorkspaceJpaRepository workspaceJpaRepository;
     private final WorkspaceParticipantJpaRepository workspaceParticipantJpaRepository;
+    private final JPAQueryFactory jpaQueryFactory;
 
     @Override
     public Workspace save(Workspace workspace) {
@@ -50,5 +55,15 @@ public class WorkspaceRepositoryImpl implements WorkspaceRepository {
     @Override
     public boolean existsWorkspaceParticipantByMemberIdAndWorkspaceId(String memberId, Long workspaceId) {
         return workspaceParticipantJpaRepository.existsWorkspaceParticipantByMemberIdAndWorkspaceId(memberId, workspaceId);
+    }
+
+    @Override
+    public Role findParticipantRoleByMemberId(String memberId, Long workspaceId) {
+        return jpaQueryFactory
+                .select(workspaceParticipant.role)
+                .from(workspaceParticipant)
+                .where(workspaceParticipant.memberId.eq(memberId)
+                        .and(workspaceParticipant.workspace.id.eq(workspaceId)))
+                .fetchFirst();
     }
 }

--- a/src/main/java/com/daon/backend/task/service/WorkspaceService.java
+++ b/src/main/java/com/daon/backend/task/service/WorkspaceService.java
@@ -4,20 +4,19 @@ import com.daon.backend.task.domain.workspace.*;
 import com.daon.backend.task.dto.request.CheckJoinCodeRequestDto;
 import com.daon.backend.task.dto.request.CreateWorkspaceRequestDto;
 import com.daon.backend.task.dto.request.JoinWorkspaceRequestDto;
-import com.daon.backend.task.dto.response.FindParticipantsResponseDto;
-import com.daon.backend.task.dto.response.FindProfileResponseDto;
-import com.daon.backend.task.dto.response.JoinWorkspaceResponseDto;
-import com.daon.backend.task.dto.response.WorkspaceListResponseDto;
+import com.daon.backend.task.dto.response.*;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
-@Service
+@Slf4j
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
+@Service
 public class WorkspaceService {
 
     private final WorkspaceRepository workspaceRepository;
@@ -106,5 +105,12 @@ public class WorkspaceService {
                         .map(FindParticipantsResponseDto.ParticipantProfile::new)
                         .collect(Collectors.toList())
         );
+    }
+
+    public CheckRoleResponseDto findParticipantRole(Long workspaceId) {
+        String memberId = sessionMemberProvider.getMemberId();
+        Role findRole = workspaceRepository.findParticipantRoleByMemberId(memberId, workspaceId);
+
+        return new CheckRoleResponseDto(findRole);
     }
 }


### PR DESCRIPTION
- 권한 처리는 전체 컨트롤러 단에서 사용되는 것이 아니기 때문에, AOP 보다는 Interceptor가 적합하다고 판단했습니다.
- API Controller 단에서 들어오는 요청에 필요한 권한을 다음과 같이 적용할 수 있습니다.

```java
@CheckRole(authority = Authority.PJ_READ)
    @GetMapping
    public CommonResponse<ProjectListResponseDto> projectList(@PathVariable Long workspaceId) {
        ProjectListResponseDto projectListResponseDto = projectService.findAllProjectInWorkspace(workspaceId);
        return CommonResponse.createSuccess(projectListResponseDto);
    }
```

- 위 코드처럼 @CheckRole 애너테이션을 사용하여 어떤 권한이 필요한지 정의합니다.
- 권한 목록은 enum으로 정의된 Authority를 참고해 주세요.