### PR TITLE
API 문서 설정에 Token 인증 설정 추가

### DIFF
--- a/src/main/java/com/daon/backend/auth/controller/AuthController.java
+++ b/src/main/java/com/daon/backend/auth/controller/AuthController.java
@@ -41,8 +41,8 @@ public class AuthController {
             @ApiResponse(responseCode = "200", description = "로그인 성공")
     })
     @PostMapping("/sign-in")
-    public ResponseEntity<CommonResponse<Void>> signIn(@RequestBody @Valid SignInRequestDto signInRequestDto) {
-        Tokens tokens = authService.signIn(signInRequestDto);
+    public ResponseEntity<CommonResponse<Void>> signIn(@RequestBody @Valid SignInRequestDto requestDto) {
+        Tokens tokens = authService.signIn(requestDto);
         ResponseCookie rtkCookie = ResponseCookie.from("rtk", tokens.getRefreshToken().getValue())
                 .path("/")
                 .httpOnly(true)

--- a/src/main/java/com/daon/backend/config/SwaggerConfig.java
+++ b/src/main/java/com/daon/backend/config/SwaggerConfig.java
@@ -3,17 +3,24 @@ package com.daon.backend.config;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class SwaggerConfig {
 
+    final String JWT_SCHEME_NAME = "JWT Authentication";
+    final String SCHEME = "bearer";
+    final String BEARER_FORMAT = "JWT";
+
     @Bean
     public OpenAPI openAPI() {
         return new OpenAPI()
-                .components(new Components())
-                .info(apiInfo());
+                .info(apiInfo())
+                .addSecurityItem(securityRequirement)
+                .components(components);
     }
 
     private Info apiInfo() {
@@ -23,4 +30,17 @@ public class SwaggerConfig {
                         "Request Dto 등 모든 필드에 부가 정보를 다는 것은 번거롭기도 하고 논의된 사항(시간 자원의 한계)에 맞지 않기 때문에 우선 제외했습니다.")
                 .version("1.0.0");
     }
+
+    private final SecurityRequirement securityRequirement = new SecurityRequirement()
+            .addList(JWT_SCHEME_NAME);
+
+    private final Components components = new Components()
+            .addSecuritySchemes(
+                    JWT_SCHEME_NAME,
+                    new SecurityScheme()
+                            .name(JWT_SCHEME_NAME)
+                            .type(SecurityScheme.Type.HTTP)
+                            .scheme(SCHEME)
+                            .bearerFormat(BEARER_FORMAT)
+            );
 }

--- a/src/main/java/com/daon/backend/member/controller/MemberController.java
+++ b/src/main/java/com/daon/backend/member/controller/MemberController.java
@@ -27,8 +27,8 @@ public class MemberController {
     })
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/sign-up")
-    public CommonResponse<Void> signUp(@RequestBody @Valid SignUpRequestDto signUpRequestDto) {
-        memberService.signUp(signUpRequestDto);
+    public CommonResponse<Void> signUp(@RequestBody @Valid SignUpRequestDto requestDto) {
+        memberService.signUp(requestDto);
 
         return CommonResponse.createSuccess(null);
     }

--- a/src/main/java/com/daon/backend/task/controller/BoardController.java
+++ b/src/main/java/com/daon/backend/task/controller/BoardController.java
@@ -16,6 +16,7 @@ import javax.validation.Valid;
 
 import static com.daon.backend.task.domain.authority.Authority.BD_CREATE;
 import static com.daon.backend.task.domain.authority.Authority.BD_READ;
+import static com.daon.backend.task.domain.authority.CheckRole.MembershipType.*;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/workspaces/{workspaceId}/projects/{projectId}/boards")
@@ -29,7 +30,7 @@ public class BoardController {
             @ApiResponse(responseCode = "201", description = "보드 생성 성공")
     })
     @ResponseStatus(HttpStatus.CREATED)
-    @CheckRole(authority = BD_CREATE)
+    @CheckRole(authority = BD_CREATE, membership = PROJECT)
     @PostMapping
     public CommonResponse<Void> createBoard(@PathVariable("workspaceId") Long workspaceId,
                                                               @PathVariable("projectId") Long projectId,
@@ -43,7 +44,7 @@ public class BoardController {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "보드 목록 조회 성공")
     })
-    @CheckRole(authority = BD_READ)
+    @CheckRole(authority = BD_READ, membership = PROJECT)
     @GetMapping
     public CommonResponse<FindBoardsResponseDto> findBoards(@PathVariable("workspaceId") Long workspaceId,
                                                             @PathVariable("projectId") Long projectId) {

--- a/src/main/java/com/daon/backend/task/controller/ProjectController.java
+++ b/src/main/java/com/daon/backend/task/controller/ProjectController.java
@@ -20,6 +20,8 @@ import javax.validation.Valid;
 
 import static com.daon.backend.task.domain.authority.Authority.PJ_CREATE;
 import static com.daon.backend.task.domain.authority.Authority.PJ_READ;
+import static com.daon.backend.task.domain.authority.CheckRole.MembershipType.PROJECT;
+import static com.daon.backend.task.domain.authority.CheckRole.MembershipType.WORKSPACE;
 
 @Slf4j
 @RestController
@@ -35,7 +37,7 @@ public class ProjectController {
             @ApiResponse(responseCode = "201", description = "프로젝트 생성 성공")
     })
     @ResponseStatus(HttpStatus.CREATED)
-    @CheckRole(authority = PJ_CREATE)
+    @CheckRole(authority = PJ_CREATE, membership = WORKSPACE)
     @PostMapping
     public CommonResponse<CreateProjectResponseDto> createProject(
             @PathVariable Long workspaceId,
@@ -49,9 +51,9 @@ public class ProjectController {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "프로젝트 목록 조회 성공")
     })
-    @CheckRole(authority = PJ_READ)
+    @CheckRole(authority = PJ_READ, membership = WORKSPACE)
     @GetMapping
-    public CommonResponse<ProjectListResponseDto> projectList(@PathVariable Long workspaceId) {
+    public CommonResponse<ProjectListResponseDto> findProjects(@PathVariable Long workspaceId) {
         ProjectListResponseDto projectListResponseDto = projectService.findAllProjectInWorkspace(workspaceId);
         return CommonResponse.createSuccess(projectListResponseDto);
     }
@@ -60,7 +62,7 @@ public class ProjectController {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "프로젝트 초대 성공")
     })
-    @CheckRole(authority = PJ_CREATE)
+    @CheckRole(authority = PJ_CREATE, membership = PROJECT)
     @PostMapping("/{projectId}/invite")
     public CommonResponse<Void> inviteWorkspaceParticipant(@PathVariable("workspaceId") Long workspaceId,
                                                            @PathVariable("projectId") Long projectId,

--- a/src/main/java/com/daon/backend/task/controller/ProjectExceptionHandler.java
+++ b/src/main/java/com/daon/backend/task/controller/ProjectExceptionHandler.java
@@ -1,0 +1,29 @@
+package com.daon.backend.task.controller;
+
+import com.daon.backend.common.exception.DomainSpecificAdvice;
+import com.daon.backend.common.response.CommonResponse;
+import com.daon.backend.task.domain.project.NotProjectParticipantException;
+import com.daon.backend.task.domain.project.ProjectNotFoundException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@Slf4j
+@DomainSpecificAdvice
+public class ProjectExceptionHandler {
+
+    @ExceptionHandler(NotProjectParticipantException.class)
+    public ResponseEntity<CommonResponse<Void>> notProjectParticipantException(NotProjectParticipantException e) {
+        log.info("{}", e.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(CommonResponse.createError("해당 프로젝트의 회원이 아닙니다."));
+    }
+
+    @ExceptionHandler(ProjectNotFoundException.class)
+    public ResponseEntity<CommonResponse<Void>> projectNotFoundException(ProjectNotFoundException e) {
+        log.info("{}", e.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(CommonResponse.createError("존재하지 않는 프로젝트입니다."));
+    }
+}

--- a/src/main/java/com/daon/backend/task/controller/WorkspaceController.java
+++ b/src/main/java/com/daon/backend/task/controller/WorkspaceController.java
@@ -21,6 +21,7 @@ import javax.validation.Valid;
 
 import static com.daon.backend.task.domain.authority.Authority.WSP_INVITE;
 import static com.daon.backend.task.domain.authority.Authority.WS_READ;
+import static com.daon.backend.task.domain.authority.CheckRole.MembershipType.WORKSPACE;
 
 @Slf4j
 @RestController
@@ -48,9 +49,8 @@ public class WorkspaceController {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "워크스페이스 목록 조회 성공")
     })
-    @CheckRole(authority = WS_READ)
     @GetMapping
-    public CommonResponse<WorkspaceListResponseDto> workspaceList() {
+    public CommonResponse<WorkspaceListResponseDto> findWorkspaces() {
         WorkspaceListResponseDto workspaceListResponseDto = workspaceService.findAllWorkspace();
         return CommonResponse.createSuccess(workspaceListResponseDto);
     }
@@ -59,7 +59,7 @@ public class WorkspaceController {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "참여코드 확인 성공")
     })
-    @CheckRole(authority = WSP_INVITE)
+    @CheckRole(authority = WSP_INVITE, membership = WORKSPACE)
     @PostMapping("/code")
     public CommonResponse<Void> checkJoinCode(@RequestBody @Valid CheckJoinCodeRequestDto requestDto) {
         workspaceService.checkJoinCode(requestDto);
@@ -82,7 +82,7 @@ public class WorkspaceController {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "프로필 조회 성공")
     })
-    @CheckRole(authority = WS_READ)
+    @CheckRole(authority = WS_READ, membership = WORKSPACE)
     @GetMapping("/{workspaceId}/profile/me")
     public CommonResponse<FindProfileResponseDto> findProfile(@PathVariable("workspaceId") Long workspaceId) {
         FindProfileResponseDto result = workspaceService.findProfile(workspaceId);
@@ -94,7 +94,7 @@ public class WorkspaceController {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "워크스페이스 구성원 목록 조회 성공")
     })
-    @CheckRole(authority = WS_READ)
+    @CheckRole(authority = WS_READ, membership = WORKSPACE)
     @GetMapping("/{workspaceId}/participants")
     public CommonResponse<FindParticipantsResponseDto> findParticipants(@PathVariable("workspaceId") Long workspaceId) {
         FindParticipantsResponseDto result = workspaceService.findParticipants(workspaceId);
@@ -106,7 +106,7 @@ public class WorkspaceController {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "회원 초대 성공")
     })
-    @CheckRole(authority = WSP_INVITE)
+    @CheckRole(authority = WSP_INVITE, membership = WORKSPACE)
     @PostMapping("/{workspaceId}/invite")
     public CommonResponse<Void> inviteMember(@PathVariable("workspaceId") Long workspaceId,
                                              @RequestBody InviteMemberRequestDto requestDto) {

--- a/src/main/java/com/daon/backend/task/domain/authority/CheckRole.java
+++ b/src/main/java/com/daon/backend/task/domain/authority/CheckRole.java
@@ -10,4 +10,11 @@ import java.lang.annotation.Target;
 public @interface CheckRole {
 
     Authority[] authority();
+
+    MembershipType membership();
+
+    enum MembershipType {
+        WORKSPACE,
+        PROJECT,
+    }
 }

--- a/src/main/java/com/daon/backend/task/domain/project/Project.java
+++ b/src/main/java/com/daon/backend/task/domain/project/Project.java
@@ -66,4 +66,9 @@ public class Project extends BaseTimeEntity {
                     throw new SameBoardExistsException(title);
                 });
     }
+
+    public boolean isProjectParticipants(String memberId) {
+        return this.participants.stream()
+                .anyMatch(projectParticipant -> projectParticipant.getMemberId().equals(memberId));
+    }
 }

--- a/src/main/java/com/daon/backend/task/domain/workspace/Workspace.java
+++ b/src/main/java/com/daon/backend/task/domain/workspace/Workspace.java
@@ -97,4 +97,8 @@ public class Workspace extends BaseTimeEntity {
         return UUID.randomUUID().toString().replace("-", "").substring(0, 10);
     }
 
+    public boolean isWorkspaceParticipants(String memberId) {
+        return this.participants.stream()
+                .anyMatch(workspaceParticipant -> workspaceParticipant.getMemberId().equals(memberId));
+    }
 }

--- a/src/main/java/com/daon/backend/task/domain/workspace/WorkspaceRepository.java
+++ b/src/main/java/com/daon/backend/task/domain/workspace/WorkspaceRepository.java
@@ -9,6 +9,8 @@ public interface WorkspaceRepository {
 
     Optional<Workspace> findWorkspaceByWorkspaceId(Long workspaceId);
 
+    Optional<Workspace> findWorkspaceWithParticipantsByWorkspaceId(Long workspaceId);
+
     List<Workspace> findWorkspacesByMemberId(String memberId);
 
     Optional<WorkspaceParticipant> findWorkspaceParticipantByWorkspaceAndMemberId(Workspace workspace, String memberId);

--- a/src/main/java/com/daon/backend/task/infrastructure/ProjectJpaRepository.java
+++ b/src/main/java/com/daon/backend/task/infrastructure/ProjectJpaRepository.java
@@ -11,4 +11,6 @@ public interface ProjectJpaRepository extends JpaRepository<Project, Long> {
     @EntityGraph(attributePaths = "boards")
     Optional<Project> findProjectWithBoardsById(Long projectId);
 
+    @EntityGraph(attributePaths = "participants")
+    Optional<Project> findProjectWithParticipantsById(Long projectId);
 }

--- a/src/main/java/com/daon/backend/task/infrastructure/ProjectParticipantJpaRepository.java
+++ b/src/main/java/com/daon/backend/task/infrastructure/ProjectParticipantJpaRepository.java
@@ -2,7 +2,6 @@ package com.daon.backend.task.infrastructure;
 
 import com.daon.backend.task.domain.project.Project;
 import com.daon.backend.task.domain.project.ProjectParticipant;
-import com.daon.backend.task.domain.workspace.Workspace;
 import com.daon.backend.task.domain.workspace.WorkspaceParticipant;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;

--- a/src/main/java/com/daon/backend/task/infrastructure/ProjectRepositoryImpl.java
+++ b/src/main/java/com/daon/backend/task/infrastructure/ProjectRepositoryImpl.java
@@ -29,7 +29,7 @@ public class ProjectRepositoryImpl implements ProjectRepository {
 
     @Override
     public Optional<Project> findProjectWithParticipantsById(Long projectId) {
-        return projectJpaRepository.findById(projectId);
+        return projectJpaRepository.findProjectWithParticipantsById(projectId);
     }
 
     @Override

--- a/src/main/java/com/daon/backend/task/infrastructure/WorkspaceJpaRepository.java
+++ b/src/main/java/com/daon/backend/task/infrastructure/WorkspaceJpaRepository.java
@@ -1,11 +1,15 @@
 package com.daon.backend.task.infrastructure;
 
 import com.daon.backend.task.domain.workspace.Workspace;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface WorkspaceJpaRepository extends JpaRepository<Workspace, Long> {
+
+    @EntityGraph(attributePaths = "participants")
+    Optional<Workspace> findWorkspaceWithParticipantsById(Long workspaceId);
 
     Optional<Workspace> findWorkspaceByJoinCode(String joinCode);
 }

--- a/src/main/java/com/daon/backend/task/infrastructure/WorkspaceRepositoryImpl.java
+++ b/src/main/java/com/daon/backend/task/infrastructure/WorkspaceRepositoryImpl.java
@@ -32,6 +32,11 @@ public class WorkspaceRepositoryImpl implements WorkspaceRepository {
     }
 
     @Override
+    public Optional<Workspace> findWorkspaceWithParticipantsByWorkspaceId(Long workspaceId) {
+        return workspaceJpaRepository.findWorkspaceWithParticipantsById(workspaceId);
+    }
+
+    @Override
     public List<Workspace> findWorkspacesByMemberId(String memberId) {
         // 회원 아이디로
         return workspaceParticipantJpaRepository.findWorkspacesByMemberId(memberId);

--- a/src/main/java/com/daon/backend/task/service/ProjectService.java
+++ b/src/main/java/com/daon/backend/task/service/ProjectService.java
@@ -76,4 +76,11 @@ public class ProjectService {
                 .orElseThrow(() -> new ProjectNotFoundException(projectId));
         findProject.addParticipant(workspaceParticipant.getMemberId(), workspaceParticipant);
     }
+
+    public boolean isProjectParticipants(Long projectId, String memberId) {
+        Project findProject = projectRepository.findProjectWithParticipantsById(projectId)
+                .orElseThrow(() -> new ProjectNotFoundException(projectId));
+
+        return findProject.isProjectParticipants(memberId);
+    }
 }

--- a/src/main/java/com/daon/backend/task/service/WorkspaceService.java
+++ b/src/main/java/com/daon/backend/task/service/WorkspaceService.java
@@ -109,11 +109,17 @@ public class WorkspaceService {
         );
     }
 
-    public CheckRoleResponseDto findParticipantRole(Long workspaceId) {
-        String memberId = sessionMemberProvider.getMemberId();
+    public CheckRoleResponseDto findParticipantRole(Long workspaceId, String memberId) {
         Role findRole = workspaceRepository.findParticipantRoleByMemberIdAndWorkspaceId(memberId, workspaceId);
 
         return new CheckRoleResponseDto(findRole);
+    }
+
+    public boolean isWorkspaceParticipants(Long workspaceId, String memberId) {
+        Workspace findWorkspace = workspaceRepository.findWorkspaceWithParticipantsByWorkspaceId(workspaceId)
+                .orElseThrow(() -> new WorkspaceNotFoundException(workspaceId));
+
+        return findWorkspace.isWorkspaceParticipants(memberId);
     }
 
     @Transactional


### PR DESCRIPTION
- 멘토님 피드백 반영해서 API 문서화에 authorization 정보를 추가했습니다.
- API 문서에서 api 테스트를 진행할 경우, 우측 상단에 Authorize 버튼(자물쇠 이모지)을 클릭 후 임의의 value 를 입력하면 login 상태가 됩니다.
- 인증이 필요한 요청에는 로그인을 하지 않으면 401이 응답됩니다.